### PR TITLE
End of alphabet now loops around to beginning

### DIFF
--- a/SABT_MainUnit/MD12.c
+++ b/SABT_MainUnit/MD12.c
@@ -111,6 +111,7 @@ void md12_main(void) {
 					if (curr_glyph == NULL) {
 						reset_script_indices(SCRIPT_ADDRESS);
 						next_state = STATE_GENQUES;
+						curr_glyph = get_next_glyph(SCRIPT_ADDRESS);
 						break;
 					}
 					break;

--- a/SABT_MainUnit/MD2.c
+++ b/SABT_MainUnit/MD2.c
@@ -119,6 +119,7 @@ void md2_main(void) {
 					if (curr_glyph == NULL) {
 						reset_script_indices(SCRIPT_ADDRESS);
 						next_state = STATE_GENQUES;
+						curr_glyph = get_next_glyph(SCRIPT_ADDRESS);
 						break;
 					}
 					break;
@@ -203,7 +204,6 @@ void md2_main(void) {
 					play_glyph(curr_glyph);
 					play_mp3(MODE_FILESET, MP3_FOR_X_PRESS_DOTS);
 					play_dot_sequence(curr_glyph);
-					play_mp3(LANG_FILESET, MP3_TRY_AGAIN);
 					next_state = STATE_INPUT;
 				}
 			}

--- a/SABT_MainUnit/MD7.c
+++ b/SABT_MainUnit/MD7.c
@@ -111,6 +111,7 @@ void md7_main(void) {
 					if (curr_glyph == NULL) {
 						reset_script_indices(SCRIPT_ADDRESS);
 						next_state = STATE_GENQUES;
+						curr_glyph = get_next_glyph(SCRIPT_ADDRESS);
 						break;
 					}
 					break;

--- a/SABT_MainUnit/MD8.c
+++ b/SABT_MainUnit/MD8.c
@@ -119,6 +119,7 @@ void md8_main(void) {
 					if (curr_glyph == NULL) {
 						reset_script_indices(SCRIPT_ADDRESS);
 						next_state = STATE_GENQUES;
+						curr_glyph = get_next_glyph(SCRIPT_ADDRESS);
 						break;
 					}
 					break;


### PR DESCRIPTION
Bug fix for invalid current glyph after reaching the end of an alphabet.
(Bug #6.7)
